### PR TITLE
Support Windows paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function createGzipStaticMiddleware(options, cb) {
   walker.on('file', function(file, stat, linkPath) {
     var usePath = linkPath || file;
     if (ignoreFile(usePath)) return;
-    var relName = '/' + path.relative(dir, usePath);
+    var relName = '/' + path.relative(dir, usePath).replace('\\', '/');
     var compressedSink = new StreamSink();
     var uncompressedSink = new StreamSink();
     var hashSink = new StreamSink();


### PR DESCRIPTION
Windows-paths (containing \\) was not translated properly, which caused files in subfolders to be stored under the wrong key.