### PR TITLE
Add charset to Content-Type when possible

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,9 +36,11 @@ function createGzipStaticMiddleware(options, cb) {
     var hashSink = new StreamSink();
     var inStream = fs.createReadStream(file);
     var cacheObj;
+    var mimeType = mime.lookup(relName);
     cache[relName] = cacheObj = {
       sink: null,
-      mime: mime.lookup(relName),
+      mime: mimeType,
+      charset: mime.charsets.lookup(mimeType),
       mtime: stat.mtime,
       hash: null,
       compressed: null,
@@ -110,7 +112,7 @@ function createGzipStaticMiddleware(options, cb) {
       }
 
       var sink = c.sink;
-      resp.setHeader('Content-Type', c.mime);
+      resp.setHeader('Content-Type', c.mime + (c.charset ? '; charset=' + c.charset : ''));
       resp.setHeader('Cache-Control', cacheControlHeader);
       resp.setHeader('ETag', c.hash);
       if (req.headers['accept-encoding'] == null) {


### PR DESCRIPTION
Requesting this because browsers misbehave on a missing charset - serving a website from memory using this module would previously result in mangled regional (non-ASCII) characters. With this patch, a test site with Polish characters served from `connect-static` appears OK, whereas before it would be auto-detected as "ISO-8859-2" in Chromium.

Original commit text:
This change causes a "charset" parameter to be appended to the Content-Type header set when serving files from the cache, if possible.
Currently, only text files (text/* MIME type) are recognized and automatically marked as UTF-8 (this behaviour depends on the "mime" npm package).
Each cache entry now includes a "charset" property, either undefined or a string.